### PR TITLE
fix!: Discrepancy in flop counting

### DIFF
--- a/frameworks/run.py
+++ b/frameworks/run.py
@@ -69,7 +69,9 @@ def wrap_experiment_with_flops(experiment_cls: Type, run_name: str) -> Type:
                 )
             elif lm_config["learning_module_class"] == DisplacementGraphLM:
                 print("The current experiment uses DisplacementGraphLM (pretraining experiment) \
-                      \nwhich has no FlopCounting version implemented.")
+                      \nwhich has no FlopCounting version implemented. \
+                      \nThis is fine for pre-training FLOP counting, as we only implement a FlopCounting version of EvidenceGraphLM \
+                      \nto catch certain inference-only related FLOPs.")
             else:
                 raise ValueError(
                     f"FLOP counting is not implemented for learning module class: {lm_config['learning_module_class']}")

--- a/frameworks/run.py
+++ b/frameworks/run.py
@@ -21,6 +21,7 @@ from tbp.monty.frameworks.run import (
     run,
 )
 from tbp.monty.frameworks.models.evidence_matching import EvidenceGraphLM
+from tbp.monty.frameworks.models.displacement_matching import DisplacementGraphLM
 
 from floppy.counting.logger import LogLevel
 from floppy.counting.tracer import MontyFlopTracer
@@ -66,11 +67,12 @@ def wrap_experiment_with_flops(experiment_cls: Type, run_name: str) -> Type:
                 lm_config["learning_module_args"]["gsg_class"] = (
                     FlopCountingEvidenceGoalStateGenerator
                 )
+            elif lm_config["learning_module_class"] == DisplacementGraphLM:
+                print("The current experiment uses DisplacementGraphLM (pretraining experiment) \
+                      \nwhich has no FlopCounting version implemented.")
             else:
-                print(
-                    f"FLOP counting is not implemented for learning module class: {lm_config['learning_module_class']}" \
-                    "Skipping FLOP counting for this learning module (normal during pretraining, which uses DisplacementGraphLM)."
-                )
+                raise ValueError(
+                    f"FLOP counting is not implemented for learning module class: {lm_config['learning_module_class']}")
 
         original_setup(self, modified_config)
 


### PR DESCRIPTION
This script fixes the issue encountered with FLOP counting discrepancies. The fundamental reason was that during inference, EvidenceGraphLM was not properly converted to FlopCountingEvidenceGraphLM, which neglected all counts related to KDTree queries. 

Tagging @nielsleadholm to let him know the update. 